### PR TITLE
Build system fixes, improvements, and cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,7 @@ SUBS =
 SUBS += lib
 SUBS += moctl
 
-DIR = $(shell pwd)
-CFLAGS = -I$(DIR)/include/ -Wall -Werror
-CC = gcc
-
-export CFLAGS
-export CC
+include Makefile.inc
 
 all: $(SUBS)
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: $(SUBS)
 lib:
 	make -C lib/
 
-moctl:
+moctl: lib
 	make -C moctl/
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ lib:
 moctl: lib
 	make -C moctl/
 
-clean:
-	make -C lib/ clean
-	make -C moctl/ clean
+install clean:
+	make -C lib/ $@
+	make -C moctl/ $@
 
 test: all
 	make -C test/
 
-.PHONY: all clean $(SUBS)
+.PHONY: all install clean $(SUBS)
 .DEFAULT_GOAL: all

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ install clean:
 test: all
 	make -C test/
 
-.PHONY: all install clean $(SUBS)
+.PHONY: all install clean test $(SUBS)
 .DEFAULT_GOAL: all

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,0 +1,2 @@
+CFLAGS = -Wall -Werror
+CC = gcc

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,2 +1,14 @@
 CFLAGS = -Wall -Werror
 CC = gcc
+
+# Installation directories
+BINDIR=/usr/bin
+LIBDIR=/usr/lib
+# For DEB-based systems
+DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null)
+ifneq "$(DEB_HOST_MULTIARCH)" ""
+LIBDIR=/usr/lib/$(DEB_HOST_MULTIARCH)
+# For RPM-based systems
+else ifeq "$(shell uname -m)" "x86_64"
+LIBDIR=/usr/lib64
+endif

--- a/include/mosaic.h
+++ b/include/mosaic.h
@@ -3,6 +3,11 @@
 struct mosaic;
 struct tessera;
 
+/* Mark for library functions that are not part of public API
+ * but are still used by our own tools like moctl.
+ */
+#define LIB_PROTECTED __attribute__ ((visibility("default")))
+
 struct mosaic_ops {
 	const char *name;
 
@@ -78,7 +83,7 @@ int parse_mosaic_subdir_layout(struct mosaic *m, char *key, char *val);
 int bind_mosaic_subdir_loc(struct mosaic *m, const char *path, int mount_flags);
 
 const struct mosaic_ops *mosaic_find_ops(char *type);
-int mosaic_parse_config(const char *cfg, struct mosaic *);
+LIB_PROTECTED int mosaic_parse_config(const char *cfg, struct mosaic *);
 int bind_tess_loc(struct mosaic *m, struct tessera *t, const char *path, int mount_flags);
 
 extern const struct mosaic_ops mosaic_fsimg;

--- a/include/uapi/mosaic.h
+++ b/include/uapi/mosaic.h
@@ -1,6 +1,8 @@
 #ifndef __MOSAIC_UAPI_H__
 #define __MOSAIC_UAPI_H__
 
+#pragma GCC visibility push(default)
+
 /*
  * Mosaic management
  */
@@ -55,4 +57,6 @@ int mosaic_get_tess_size(tessera_t t, unsigned long *size_in_blocks);
 /* Misc */
 typedef void (*mosaic_log_fn)(const char *f, ...)
 	            __attribute__ ((format(printf, 1, 2)));
+
+#pragma GCC visibility pop
 #endif

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -2,3 +2,4 @@
 *.d
 .*
 libmosaic.so
+libmosaic.so.*

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -3,3 +3,4 @@
 .*
 libmosaic.so
 libmosaic.so.*
+mosaic.pc

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,4 +1,10 @@
-TGT = libmosaic.so
+LIBVER_MAJOR := 0
+LIBVER_MINOR := 0
+
+LIBMOSAIC_SO		:= libmosaic.so
+LIBMOSAIC_SO_X		:= $(LIBMOSAIC_SO).$(LIBVER_MAJOR)
+LIBMOSAIC_SO_X_Y	:= $(LIBMOSAIC_SO).$(LIBVER_MAJOR).$(LIBVER_MINOR)
+
 OBJS =
 OBJS += mosaic.o
 OBJS += tessera.o
@@ -10,10 +16,21 @@ OBJS += yaml.o
 OBJS += log.o
 OBJS += util.o
 
-all: $(TGT)
+CFLAGS+= -fPIC
+LDFLAGS+= -shared -Wl,-soname,$(LIBMOSAIC_SO_X)
+LDLIBS+= -lyaml
 
-$(TGT): $(OBJS)
-	$(CC) -shared -o $@ $^ -lyaml
+all: $(LIBMOSAIC_SO)
+.PHONY: all
+
+$(LIBMOSAIC_SO_X_Y): $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -o $@
+
+$(LIBMOSAIC_SO_X): $(LIBMOSAIC_SO_X_Y)
+	ln -sf $^ $@
+
+$(LIBMOSAIC_SO): $(LIBMOSAIC_SO_X)
+	ln -sf $^ $@
 
 %.d: %.c
 	$(CC) $(CFLAGS) -M -MT $@ -MT $(patsubst %.d,%.o,$@) $< -o $@
@@ -23,9 +40,8 @@ ifneq ($(MAKECMDGOAL),clean)
 endif
 
 %.o: %.c
-	$(CC) $(CFLAGS) $< -c -fPIC -o $@
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 clean:
-	rm -rf $(TGT) $(OBJS) *.d
-
-.PHONY: all clean
+	rm -f $(OBJS) *.so *.so.* *.d
+.PHONY: clean

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,5 +1,6 @@
 include ../Makefile.inc
 
+VERSION	     := 0.0
 LIBVER_MAJOR := 0
 LIBVER_MINOR := 0
 
@@ -7,6 +8,9 @@ LIBMOSAIC		:= libmosaic.a
 LIBMOSAIC_SO		:= libmosaic.so
 LIBMOSAIC_SO_X		:= $(LIBMOSAIC_SO).$(LIBVER_MAJOR)
 LIBMOSAIC_SO_X_Y	:= $(LIBMOSAIC_SO).$(LIBVER_MAJOR).$(LIBVER_MINOR)
+
+PC = mosaic.pc
+PCDIR=$(LIBDIR)/pkgconfig
 
 OBJS =
 OBJS += mosaic.o
@@ -24,7 +28,7 @@ CFLAGS+= -fPIC -fvisibility=hidden
 LDFLAGS+= -shared -Wl,-soname,$(LIBMOSAIC_SO_X)
 LDLIBS+= -lyaml
 
-all: $(LIBMOSAIC_SO)
+all: $(LIBMOSAIC_SO) $(PC)
 .PHONY: all
 
 $(LIBMOSAIC): $(OBJS)
@@ -40,7 +44,19 @@ $(LIBMOSAIC_SO_X): $(LIBMOSAIC_SO_X_Y)
 $(LIBMOSAIC_SO): $(LIBMOSAIC_SO_X)
 	ln -sf $^ $@
 
-install: $(LIBMOSAIC_SO)
+$(PC): $(PC).in
+	sed \
+		-e 's|@VERSION@|$(VERSION)|g' \
+		-e 's|@LIBDIR@|$(LIBDIR)|g' \
+		$^ > $@
+
+install-pc: $(PC)
+	install -d $(DESTDIR)$(PCDIR)
+	install -m 644 $(PC) $(DESTDIR)$(PCDIR)
+.PHONY: install-pc
+
+
+install: $(LIBMOSAIC_SO) install-pc
 	install -d $(DESTDIR)$(LIBDIR)
 	install -m 755 $(LIBMOSAIC_SO_X_Y) $(DESTDIR)$(LIBDIR)
 	cp -a $(LIBMOSAIC_SO_X) $(LIBMOSAIC_SO) $(DESTDIR)$(LIBDIR)
@@ -57,5 +73,5 @@ endif
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 clean:
-	rm -f $(OBJS) *.a *.so *.so.* *.d
+	rm -f $(OBJS) $(PC) *.a *.so *.so.* *.d
 .PHONY: clean

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -13,7 +13,7 @@ OBJS += util.o
 all: $(TGT)
 
 $(TGT): $(OBJS)
-	$(CC) -shared -lyaml -o $@ $^
+	$(CC) -shared -o $@ $^ -lyaml
 
 %.d: %.c
 	$(CC) $(CFLAGS) -M -MT $@ -MT $(patsubst %.d,%.o,$@) $< -o $@

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,3 +1,5 @@
+include ../Makefile.inc
+
 LIBVER_MAJOR := 0
 LIBVER_MINOR := 0
 
@@ -17,6 +19,7 @@ OBJS += yaml.o
 OBJS += log.o
 OBJS += util.o
 
+CFLAGS+= -I../include
 CFLAGS+= -fPIC -fvisibility=hidden
 LDFLAGS+= -shared -Wl,-soname,$(LIBMOSAIC_SO_X)
 LDLIBS+= -lyaml

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,7 @@
 LIBVER_MAJOR := 0
 LIBVER_MINOR := 0
 
+LIBMOSAIC		:= libmosaic.a
 LIBMOSAIC_SO		:= libmosaic.so
 LIBMOSAIC_SO_X		:= $(LIBMOSAIC_SO).$(LIBVER_MAJOR)
 LIBMOSAIC_SO_X_Y	:= $(LIBMOSAIC_SO).$(LIBVER_MAJOR).$(LIBVER_MINOR)
@@ -23,6 +24,10 @@ LDLIBS+= -lyaml
 all: $(LIBMOSAIC_SO)
 .PHONY: all
 
+$(LIBMOSAIC): $(OBJS)
+	ar rcs $@ $+
+	ranlib $@
+
 $(LIBMOSAIC_SO_X_Y): $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
@@ -43,5 +48,5 @@ endif
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 clean:
-	rm -f $(OBJS) *.so *.so.* *.d
+	rm -f $(OBJS) *.a *.so *.so.* *.d
 .PHONY: clean

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -40,6 +40,12 @@ $(LIBMOSAIC_SO_X): $(LIBMOSAIC_SO_X_Y)
 $(LIBMOSAIC_SO): $(LIBMOSAIC_SO_X)
 	ln -sf $^ $@
 
+install: $(LIBMOSAIC_SO)
+	install -d $(DESTDIR)$(LIBDIR)
+	install -m 755 $(LIBMOSAIC_SO_X_Y) $(DESTDIR)$(LIBDIR)
+	cp -a $(LIBMOSAIC_SO_X) $(LIBMOSAIC_SO) $(DESTDIR)$(LIBDIR)
+.PHONY: install
+
 %.d: %.c
 	$(CC) $(CFLAGS) -M -MT $@ -MT $(patsubst %.d,%.o,$@) $< -o $@
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -16,7 +16,7 @@ OBJS += yaml.o
 OBJS += log.o
 OBJS += util.o
 
-CFLAGS+= -fPIC
+CFLAGS+= -fPIC -fvisibility=hidden
 LDFLAGS+= -shared -Wl,-soname,$(LIBMOSAIC_SO_X)
 LDLIBS+= -lyaml
 

--- a/lib/mosaic.pc.in
+++ b/lib/mosaic.pc.in
@@ -1,0 +1,10 @@
+libdir=@LIBDIR@
+
+Name: mosaic
+Version: @VERSION@
+Description: mosaic library
+Requires:
+Requires.private: yaml-0.1
+Libs: -L${libdir} -lmosaic
+Libs.private:
+Cflags:

--- a/moctl/Makefile
+++ b/moctl/Makefile
@@ -1,7 +1,11 @@
+include ../Makefile.inc
+
 TGT = moctl
 OBJS =
 OBJS += main.o
 OBJS += create.o
+
+CFLAGS += -I../include
 
 all: $(TGT)
 

--- a/moctl/Makefile
+++ b/moctl/Makefile
@@ -8,6 +8,7 @@ OBJS += create.o
 CFLAGS += -I../include
 
 all: $(TGT)
+.PHONY: all
 
 $(TGT): $(OBJS)
 	$(CC) -o $@ $^ -lmosaic -L../lib/
@@ -22,7 +23,11 @@ endif
 %.o: %.c
 	$(CC) $(CFLAGS) $< -c -fPIC -o $@
 
+install: $(TGT)
+	install -d $(DESTDIR)$(BINDIR)
+	install -m 755 $(TGT) $(DESTDIR)$(BINDIR)
+.PHONY: install
+
 clean:
 	rm -rf $(TGT) $(OBJS) *.d
-
-.PHONY: all clean
+.PHONY: clean

--- a/moctl/Makefile
+++ b/moctl/Makefile
@@ -1,17 +1,27 @@
 include ../Makefile.inc
 
-TGT = moctl
+LIB_PATH=../lib
+
+BIN = moctl
+REALBIN = .$(BIN)-real
 OBJS =
 OBJS += main.o
 OBJS += create.o
 
 CFLAGS += -fPIE -I../include
 
-all: $(TGT)
+all: $(BIN)
 .PHONY: all
 
-$(TGT): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $^ -lmosaic -L../lib/
+$(BIN): wrapper.sh.in $(REALBIN)
+	sed \
+		 -e 's|@REALBIN@|$(REALBIN)|g' \
+		 -e 's|@LIB_PATH@|$(LIB_PATH)|g' \
+		< $< > $@ \
+	&& chmod a+x $@
+
+$(REALBIN): $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $^ -lmosaic -L $(LIB_PATH)
 
 %.d: %.c
 	$(CC) $(CFLAGS) -M -MT $@ -MT $(patsubst %.d,%.o,$@) $< -o $@
@@ -23,11 +33,11 @@ endif
 %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-install: $(TGT)
+install: $(REALBIN)
 	install -d $(DESTDIR)$(BINDIR)
-	install -m 755 $(TGT) $(DESTDIR)$(BINDIR)
+	install -m 755 $(REALBIN) $(DESTDIR)$(BINDIR)/$(BIN)
 .PHONY: install
 
 clean:
-	rm -rf $(TGT) $(OBJS) *.d
+	rm -rf $(BIN) $(REALBIN) $(OBJS) *.d
 .PHONY: clean

--- a/moctl/Makefile
+++ b/moctl/Makefile
@@ -6,7 +6,7 @@ OBJS += create.o
 all: $(TGT)
 
 $(TGT): $(OBJS)
-	$(CC) -o $@ $^ -lmosaic -lyaml -L../lib/
+	$(CC) -o $@ $^ -lmosaic -L../lib/
 
 %.d: %.c
 	$(CC) $(CFLAGS) -M -MT $@ -MT $(patsubst %.d,%.o,$@) $< -o $@

--- a/moctl/Makefile
+++ b/moctl/Makefile
@@ -5,13 +5,13 @@ OBJS =
 OBJS += main.o
 OBJS += create.o
 
-CFLAGS += -I../include
+CFLAGS += -fPIE -I../include
 
 all: $(TGT)
 .PHONY: all
 
 $(TGT): $(OBJS)
-	$(CC) -o $@ $^ -lmosaic -L../lib/
+	$(CC) $(CFLAGS) -o $@ $^ -lmosaic -L../lib/
 
 %.d: %.c
 	$(CC) $(CFLAGS) -M -MT $@ -MT $(patsubst %.d,%.o,$@) $< -o $@
@@ -21,7 +21,7 @@ ifneq ($(MAKECMDGOAL),clean)
 endif
 
 %.o: %.c
-	$(CC) $(CFLAGS) $< -c -fPIC -o $@
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 install: $(TGT)
 	install -d $(DESTDIR)$(BINDIR)

--- a/moctl/wrapper.sh.in
+++ b/moctl/wrapper.sh.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# This is a wrapper around @REALBIN@ to be able to run it with a library
+# from @LIB_PATH@ that might not yet be installed into a proper place.
+
+BASEDIR=$(dirname $0)
+LD_LIBRARY_PATH=${BASEDIR}/@LIB_PATH@ exec ${BASEDIR}/@REALBIN@

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,4 +11,4 @@ plain:
 btrfs:
 	./run.sh ${TESTS} btrfs
 
-.PHONY: all
+.PHONY: all loop plain btrfs

--- a/test/env.sh
+++ b/test/env.sh
@@ -1,4 +1,3 @@
-export LD_LIBRARY_PATH="$(pwd)/../lib/"
 moctl="../moctl/moctl"
 set -x
 


### PR DESCRIPTION
This set of patches is aimed to straighten out mosaic build system, i.e. Makefiles.

Some commits are pure fixes, some others are cleanups, some are bringing in new functionality.

In particular, it is very important that:
- everything is being built correctly (consistent CFLAGS, no over/under-linking etc)
- the so library be versioned from the very beginning
- there's an install target so packagers don't come with their own
- there's a .pc provided from the very beginning so library users rely on pkg-config

~~What this patch doesn't address is a dirty hack of using -L ../lib in moctl/Makefile. This is something that should be fixed, as resulting binary, once installed, looks for the libraries in a wrong place.~~
Last commit in the series addresses a problem of using a binary with a non-installed library. The method is the same as used by libtool, and IMHO makes things much easier for a developer.

Please review
