### PR TITLE
Misc nitpicks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-*.o
-mosaic.conf
 tags
-.*
+cscope.out

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,5 +1,9 @@
-CFLAGS = -Wall -Werror
 CC = gcc
+CFLAGS = -Wall -Werror -Wextra
+
+# Temporarily hide some minor warnings (to show, use -Wno-error=...)
+CFLAGS += -Wno-unused-parameter -Wno-sign-compare
+#CFLAGS += -Wno-error=unused-parameter -Wno-error=sign-compare
 
 # Installation directories
 BINDIR=/usr/bin

--- a/doc/config.txt
+++ b/doc/config.txt
@@ -1,13 +1,13 @@
 Config file is yaml file consisting of a mapping with the
 keys being
 
-* type: the backend type. Can be onw of btrfs, fsimg, plain.
+* type: the backend type. Can be one of btrfs, fsimg, plain.
 
 * location: a string describing where the tessera is. It's
   type-specific.
 
 * default_fs: the filesystem to be put on tesserae. Some
-  backends do not support arbitrary value of this, som
+  backends do not support arbitrary value of this, some
   have defaults (ext4).
 
 * layout: the way metadata and tesserae are put on the

--- a/doc/libmosaic.txt
+++ b/doc/libmosaic.txt
@@ -8,9 +8,9 @@ The API is described in include/uapi/mosaic.h
 * mosaic_t mosaic_open(const char *cfg, int open_flags)
   void mosaic_close(mosaic_t m)
 
-  Open and close the mosaic hanlde.
+  Open and close the mosaic handle.
 
-  @cfg is path to config file of mosaic name. In the former 
+  @cfg is path to config file of mosaic name. In the former
   case the path is just opened, in the latter the mosaic
   config is looked up in the default directory (/etc).
 
@@ -45,7 +45,7 @@ The API is described in include/uapi/mosaic.h
 
 * int mosaic_drop_tess(tessera_t t, int drop_flags)
 
-  Removes tessera and ALL DATA ON IT! 
+  Removes tessera and ALL DATA ON IT!
 
 
 * int mosaic_resize_tess(tessera_t t, unsigned long new_size_in_blocks, int resize_flags)
@@ -61,9 +61,9 @@ The API is described in include/uapi/mosaic.h
   stops/detaches the device.
 
   The device path is but in the @devs buffer of @len length and the real
-  lenght of the path is returned.
- 
- 
+  length of the path is returned.
+
+
 * int mosaic_get_tess_size(tessera_t t, unsigned long *size_in_blocks);
 
   Puts the size (in 512-bytes blocks) into the @size_in_blocks variable.

--- a/doc/moctl.txt
+++ b/doc/moctl.txt
@@ -35,15 +35,15 @@ Actions:
   Usage: clone <tessera_from> <tessera>
 
   Clone is performed using the COW technology if the backend
-  supports this. If no the error is reported back and new
+  supports this. If it does not, the error is reported back and new
   tessera is not created.
 
 * drop: Drops tessera
 
   Usage: drop <tessera>
 
-  And removes all the data! The tesserae that were cloned from
+  Removes all the data! The tesserae that were cloned from
   this one are not affected (or error is reported if the backend
-  doesn't support such thing, but we don't have and don't plan
+  doesn't support such behavior, but we don't have and don't plan
   to have such backends).
 

--- a/moctl/main.c
+++ b/moctl/main.c
@@ -51,7 +51,7 @@ static int do_mosaic_mount(mosaic_t m, int argc, char **argv)
 
 	if (t) {
 		if (mosaic_mount_tess(t, path, flags)) {
-			perror("Can't mount mosaic");
+			perror("Can't mount tessera");
 			return 1;
 		}
 	} else {
@@ -86,12 +86,12 @@ static int do_mosaic_umount(mosaic_t m, int argc, char **argv)
 
 	if (t) {
 		if (mosaic_umount_tess(t, path, 0)) {
-			perror("Can't mount mosaic");
+			perror("Can't umount tessera");
 			return 1;
 		}
 	} else {
 		if (umount(path) < 0) {
-			perror("Can't mount mosaic");
+			perror("Can't umount mosaic");
 			return 1;
 		}
 	}

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,14 +1,9 @@
 TESTS = basic
+DRIVERS = plain loop btrfs
 
-all: plain loop btrfs
+all: $(DRIVERS)
 
-loop:
-	./run.sh ${TESTS} fsimg
+$(DRIVERS):
+	./run.sh ${TESTS} $@
 
-plain:
-	./run.sh ${TESTS} plain
-
-btrfs:
-	./run.sh ${TESTS} btrfs
-
-.PHONY: all loop plain btrfs
+.PHONY: all $(DRIVERS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,5 @@
 TESTS = basic
-DRIVERS = plain loop btrfs
+DRIVERS = plain fsimg btrfs
 
 all: $(DRIVERS)
 


### PR DESCRIPTION
Assorted fixes and nitpicks of various importance:
- moctl: fix some error messages
- doc: typos and whitespace nitpicks
- Makefile.inc: add -Wextra to CFLAGS
- test/Makefile: avoid repetition
- test/Makefile: fix fsimg driver name
- .gitignore: update
