### PR TITLE
Implement read-only mounts

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -13,6 +13,8 @@ char *read_var(int dirfd, const char *dir, const char *name);
 int write_var(int dirfd, const char *dir,
 		const char *name, const char *val);
 
+int unset_var(int dirfs, const char *dir, const char *name);
+
 int run_prg(char *const argv[]);
 #define HIDE_STDOUT	1 << 0	/* hide process' stdout */
 #define HIDE_STDERR	1 << 1	/* hide process' stderr */

--- a/lib/util.c
+++ b/lib/util.c
@@ -217,6 +217,18 @@ out:
 	return buf;
 }
 
+int unset_var(int dirfd, const char *dir, const char *name)
+{
+	if (unlinkat(dirfd, name, 0) < 0) {
+		if (errno != ENOENT)
+			fprintf(stderr, "%s: can't unlink %s/%s: %m\n",
+					__func__, dir, name);
+		return -1;
+	}
+
+	return 0;
+}
+
 static void arg2str(char *const argv[], char *buf, int len)
 {
 	int i, r;

--- a/moctl/main.c
+++ b/moctl/main.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <getopt.h>
 #include <sys/mount.h>
 #include "uapi/mosaic.h"
 #include "moctl.h"
@@ -38,20 +39,54 @@ static inline int argis(const char *arg, const char *is)
 	}
 }
 
-static int parse_mount_flags(char *flags)
-{
+static int parse_mount_flags(int argc, char **argv, int *flags)
+ {
+	int i;
+
+	while ((i = getopt(argc, argv, "r")) != EOF) {
+		switch (i) {
+		case 'r':
+			*flags |= MS_RDONLY;
+			break;
+		default:
+			fprintf(stderr, "%s: invalid mount flag -%c\n",
+					__func__, i);
+			return -1;
+		}
+	}
+
 	return 0;
+}
+
+static int mount_usage(int ret) {
+	printf("\n"
+"Usage: moctl NAME mount [-r] {VOLUME|-} MOUNTPOINT\n"
+"	NAME       := mosaic name (path to .mos file)\n"
+"	VOLUME     := volume to mount; \"-\" for the mosaic itself\n"
+"	MOUNTPOINT := directory to mount to\n"
+"	-r         := mount read-only\n");
+
+	return ret;
 }
 
 static int do_mosaic_mount(mosaic_t m, int argc, char **argv)
 {
 	const char *volume, *path;
 	tessera_t t = NULL;
-	int flags;
+	int flags = 0;
 
-	if (argc < 4) {
-		printf("Usage: moctl <name> mount <tessera>|- <path> <flags>\n");
-		return 1;
+	if (parse_mount_flags(argc, argv, &flags) < 0) {
+		// error is printed by parse_mount_flags()
+		return mount_usage(1);
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc < 3) {
+		fprintf(stderr, "%s: too %s arguments\n", __func__,
+				argc < 3 ? "few" : "many");
+		return mount_usage(1);
 	}
 
 	volume = argv[1];
@@ -64,7 +99,6 @@ static int do_mosaic_mount(mosaic_t m, int argc, char **argv)
 	}
 
 	path = argv[2];
-	flags = parse_mount_flags(argv[3]);
 
 	if (t) {
 		if (mosaic_mount_tess(t, path, flags)) {

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -6,11 +6,11 @@ function run_tests()
 	mkdir tmnt
 
 	echo "* Testing mosaic FS"
-	$moctl $mname mount - mmnt - || fail "Can't mount mosaic (1)"
+	$moctl $mname mount - mmnt || fail "Can't mount mosaic (1)"
 	echo "test" > mmnt/tfile
 	$moctl $mname umount - mmnt || fail "Can't umount mosaic"
 	[ -f mmnt/tfile ] && fail "Unexpected file"
-	$moctl $mname mount - mmnt - || fail "Can't mount mosaic (2)"
+	$moctl $mname mount - mmnt || fail "Can't mount mosaic (2)"
 	fgrep -q "test" mmnt/tfile || fail "File not preserved in mosaic"
 
 	echo "* Cleaning mosaic FS"
@@ -33,11 +33,11 @@ function run_tests()
 			&& fail "Unexpected success of detach (2)"
 	fi
 
-	$moctl $mname mount test_fs tmnt - || fail "Can't mount fs (1)"
+	$moctl $mname mount test_fs tmnt || fail "Can't mount fs (1)"
 	echo "t-test" > tmnt/t-tfile
 	$moctl $mname umount test_fs tmnt || fail "Can't umount fs"
 	[ -f tmnt/t-tfile ] && fail "Unexpected file"
-	$moctl $mname mount test_fs tmnt - || fail "Can't mount fs (2)"
+	$moctl $mname mount test_fs tmnt || fail "Can't mount fs (2)"
 	fgrep -q "t-test" tmnt/t-tfile || fail "File not preserved in fs"
 
 	echo "* Cleaning up tessera"

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -19,6 +19,20 @@ function run_tests()
 
 	echo "* Testing tesserae"
 	$moctl $mname new fs test_fs 512m || fail "Can't create fs"
+
+# Ideally we should have a way to ask a particular driver if a specific
+# operation is supported. Until we have that, do a little trick
+	if test -n "$TEST_MOS_ATTACH_DETACH"; then
+		$moctl $mname attach test_fs \
+			|| fail "Can't attach device"
+		$moctl $mname attach test_fs \
+			&& fail "Unexpected success of attach (2)"
+		$moctl $mname detach test_fs \
+			|| fail "Can't detach device"
+		$moctl $mname detach test_fs \
+			&& fail "Unexpected success of detach (2)"
+	fi
+
 	$moctl $mname mount test_fs tmnt - || fail "Can't mount fs (1)"
 	echo "t-test" > tmnt/t-tfile
 	$moctl $mname umount test_fs tmnt || fail "Can't umount fs"

--- a/test/fsimg.sh
+++ b/test/fsimg.sh
@@ -1,3 +1,5 @@
+TEST_MOS_ATTACH_DETACH=yes
+
 echo "*** Testing fsimg driver"
 mkdir fsimg.loc
 echo 'type: fsimg' > fsimg.mos

--- a/test/ploop.sh
+++ b/test/ploop.sh
@@ -1,3 +1,5 @@
+TEST_MOS_ATTACH_DETACH=yes
+
 echo "*** Testing ploop driver"
 mkdir ploop.dir
 echo 'type: ploop' > ploop.mos


### PR DESCRIPTION
This changes the syntax of moctl mount to be closer to one of mount, adds -r option, and fixes ploop cloning vs read-write mounts case. Depends on previous two pull requests I guess.
