### PR TITLE
Implement read-only mounts for volumes

### DIFF
--- a/lib/ploop.c
+++ b/lib/ploop.c
@@ -8,12 +8,15 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <dirent.h>
+#include <sys/mount.h>
 
 #include "mosaic.h"
 #include "tessera.h"
 #include "util.h"
 
 #include "ploop-internal.h"
+
+const char *uuidvar = "uuid-for-children";
 
 static int create_ploop(struct mosaic *m, const char *name,
 		unsigned long size_in_blocks, int make_flags)
@@ -100,7 +103,6 @@ static int clone_ploop(struct mosaic *m, struct tessera *parent,
 	 */
 	char pdir[PATH_MAX], dir[PATH_MAX];
 	char dd[PATH_MAX], pdd[PATH_MAX];
-	const char *uuidvar = "uuid-for-children";
 	int pdfd, dfd;
 	char *argv[8];
 	int i;
@@ -231,8 +233,8 @@ static int mount_ploop(struct mosaic *m, struct tessera *t,
 {
 	char dd[PATH_MAX];
 	char *argv[8];
+	int ro = (mount_flags & MS_RDONLY);
 	int i;
-	(void)mount_flags; // unused
 
 	snprintf(dd, sizeof(dd), "%s/%s/" DDXML, m->m_loc, t->t_name);
 
@@ -241,11 +243,23 @@ static int mount_ploop(struct mosaic *m, struct tessera *t,
 	argv[i++] = "mount";
 	argv[i++] = "-m";
 	argv[i++] = (char *)path;
+	if (ro)
+		argv[i++] = "-r";
 	argv[i++] = dd;
 	argv[i++] = NULL;
 
 	if (run_prg(argv) != 0)
 		return -1;
+
+	if (!ro) {
+		char *slash;
+
+		// make a directory out of 'dd' by removing file component
+		slash = strrchr(dd, '/');
+		*slash = '\0';
+		// invalidate the snapshot used for cloning
+		write_var(-1, dd, uuidvar, NULL);
+	}
 
 	return 0;
 }

--- a/lib/util.c
+++ b/lib/util.c
@@ -158,7 +158,7 @@ int write_var(int dirfd, const char *dir,
 		return -1;
 	}
 	if (write(fd, val, len) != len) {
-		fprintf(stderr, "%s: can't read %s/%s: %m\n",
+		fprintf(stderr, "%s: can't write %s/%s: %m\n",
 				__func__, dir, name);
 		ret = -1;
 	}

--- a/lib/util.c
+++ b/lib/util.c
@@ -185,6 +185,8 @@ char *read_var(int dirfd, const char *dir, const char *name)
 		return NULL;
 	}
 	s = st.st_size;
+	if (s == 0)
+		return NULL;
 
 	fd = openat(dirfd, name, O_RDONLY);
 	if (fd < 0) {

--- a/moctl/moctl.h
+++ b/moctl/moctl.h
@@ -5,4 +5,8 @@ struct mosaic;
 int create_fsimg(struct mosaic *, int argc, char **argv);
 int create_plain(struct mosaic *, int argc, char **argv);
 int create_btrfs(struct mosaic *, int argc, char **argv);
+
+#define for_each_strtok(p, str, sep)				\
+	for (p = strtok(str, sep); p; p = strtok(NULL, sep))
+
 #endif

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -6,11 +6,11 @@ function run_tests()
 	mkdir tmnt
 
 	echo "* Testing mosaic FS"
-	$moctl $mname mount - mmnt - || fail "Can't mount mosaic (1)"
+	$moctl $mname mount - mmnt || fail "Can't mount mosaic (1)"
 	echo "test" > mmnt/tfile
 	$moctl $mname umount - mmnt || fail "Can't umount mosaic"
 	[ -f mmnt/tfile ] && fail "Unexpected file"
-	$moctl $mname mount - mmnt - || fail "Can't mount mosaic (2)"
+	$moctl $mname mount - mmnt || fail "Can't mount mosaic (2)"
 	fgrep -q "test" mmnt/tfile || fail "File not preserved in mosaic"
 
 	echo "* Cleaning mosaic FS"
@@ -33,11 +33,11 @@ function run_tests()
 			&& fail "Unexpected success of detach (2)"
 	fi
 
-	$moctl $mname mount test_fs tmnt - || fail "Can't mount fs (1)"
+	$moctl $mname mount test_fs tmnt || fail "Can't mount fs (1)"
 	echo "t-test" > tmnt/t-tfile
 	$moctl $mname umount test_fs tmnt || fail "Can't umount fs"
 	[ -f tmnt/t-tfile ] && fail "Unexpected file"
-	$moctl $mname mount test_fs tmnt - || fail "Can't mount fs (2)"
+	$moctl $mname mount test_fs tmnt || fail "Can't mount fs (2)"
 	fgrep -q "t-test" tmnt/t-tfile || fail "File not preserved in fs"
 
 	echo "* Cleaning up tessera"


### PR DESCRIPTION
This changes the syntax of moctl mount to be closer to one of mount, adds an ability to specify mount options (currently only "ro"/"rw" are supported), and fixes ploop cloning vs read-write mounts case.

Previous discussion is at https://github.com/xemul/mosaic/pull/7. I hope I addressed all the concerns, except for this one:

> And, BTW, either we do s/tessera/volume/ all over the code, or continue writing tessera in usages ;)

The reason is I was trying to do something productive first. I want to do the rename, just a bit later than things will settle down a bit, if you don't mind.
