### PR TITLE
Improved parser error reporting + misc nitpicks

### DIFF
--- a/include/uapi/mosaic.h
+++ b/include/uapi/mosaic.h
@@ -22,14 +22,14 @@ volume_t mosaic_open_vol(mosaic_t m, const char *name, int open_flags);
 void mosaic_close_vol(volume_t);
 
 /*
- * Make new volumee. The first one makes raw block device, the
+ * Make a new volume. The first one makes raw block device, the
  * second one also puts filesystem on it.
  */
 int mosaic_make_vol(mosaic_t m, const char *name, unsigned long size_in_blocks, int make_flags);
 int mosaic_make_vol_fs(mosaic_t m, const char *name, unsigned long size_in_blocks, int make_flags);
 
 /*
- * Create a clone of existing volumee with COW (when possible)
+ * Create a clone of existing volume with COW (when possible)
  */
 int mosaic_clone_vol(volume_t from, const char *name, int clone_flags);
 

--- a/include/util.h
+++ b/include/util.h
@@ -18,4 +18,24 @@ int run_prg(char *const argv[]);
 #define HIDE_STDERR	1 << 1	/* hide process' stderr */
 int run_prg_rc(char *const argv[], int hide_mask, int *rc);
 
+/* Config parsing: check if val is set */
+#define CHKVAL(key, val)					\
+do {								\
+	if (!val) {						\
+		fprintf(stderr, "%s: can't parse \"%s\"\n",	\
+				__func__, key);			\
+		return -1;					\
+	}							\
+} while (0)
+
+/* Config parsing: check there's no duplicate */
+#define CHKDUP(key, to)						\
+do {								\
+	if (to) {						\
+		fprintf(stderr, "%s: duplicate \"%s\"\n",	\
+				__func__, key);			\
+		return -1;					\
+	}							\
+} while (0)
+
 #endif

--- a/lib/btrfs.c
+++ b/lib/btrfs.c
@@ -59,7 +59,7 @@ static int clone_btrfs_subvol(struct mosaic *m, struct volume *from,
 	int i;
 
 	/*
-	 * FIXME: locate volumee subvolumes in subdirectories
+	 * FIXME: locate subvolumes in subdirectories
 	 */
 	i = 0;
 	argv[i++] = "btrfs";
@@ -84,7 +84,7 @@ static int drop_btrfs_subvol(struct mosaic *m, struct volume *t,
 	int i;
 
 	/*
-	 * FIXME: locate volumee subvolumes in subdirectories
+	 * FIXME: locate subvolumes in subdirectories
 	 */
 	i = 0;
 	argv[i++] = "btrfs";

--- a/lib/mosaic.c
+++ b/lib/mosaic.c
@@ -9,6 +9,7 @@
 #include "mosaic.h"
 #include "volume.h"
 #include "log.h"
+#include "util.h"
 #include "uapi/mosaic.h"
 
 const struct mosaic_ops *mosaic_find_ops(char *type)
@@ -109,8 +110,8 @@ int parse_mosaic_subdir_layout(struct mosaic *m, char *key, char *val)
 	if (!strcmp(key, "fs")) {
 		int len;
 
-		if (p->fs_subdir)
-			free(p->fs_subdir);
+		CHKVAL(key, val);
+		CHKDUP(key, p->fs_subdir);
 
 		len = strlen(m->m_loc) + strlen(val) + 2;
 		p->fs_subdir = malloc(len);
@@ -128,6 +129,8 @@ int parse_mosaic_subdir_layout(struct mosaic *m, char *key, char *val)
 		return 0;
 	}
 #endif
+
+	fprintf(stderr, "%s: unknown layout element: %s\n", __func__, key);
 
 	return -1;
 }

--- a/moctl/main.c
+++ b/moctl/main.c
@@ -342,7 +342,8 @@ static int do_mosaic_create(char *name, int argc, char **argv)
 	else if (!strcmp(m->m_ops->name, "plain"))
 		ret = create_plain(m, argc, argv);
 	else {
-		fprintf(stderr, "Unknown mosaic type %s\n", name);
+		fprintf(stderr, "Don't know how to create %s\n",
+				m->m_ops->name);
 		ret = -1;
 	}
 


### PR DESCRIPTION
Two trivial patches with nitpicks plus a big one, trying to straighten out (or, rather, introduce) yaml parser error reporting. See individual commits descriptions for more info.
