### PR TITLE
Change mosaic config dir to /etc/mosaic

### DIFF
--- a/lib/mosaic.c
+++ b/lib/mosaic.c
@@ -16,7 +16,7 @@
 #include "uapi/mosaic.h"
 
 #ifndef MOSAIC_CONFIG_DIR
-#define MOSAIC_CONFIG_DIR	"/etc/mosaic.d"
+#define MOSAIC_CONFIG_DIR	"/etc/mosaic"
 #endif
 
 const struct mosaic_ops *mosaic_find_ops(char *type)


### PR DESCRIPTION
The usual meaning of /etc/foobar.d directory is like this --
"instead of (or in addition to) a configuration file, we have a whole
directory with configuration files, with ALL of them being used as if
their concatenation would be that configuration file (or an addition
to it)". In other words, having files in /etc/foobar.d/ has the same
effect as

 cat /etc/foobar.d/\* >> /etc/foobar.conf && rm -rf /etc/foodbar.d

To rephrase it, individual files in such /etc/foobar.d/ directories
are only useful because one can add/remove/edit those independently,
but from the point of view of software using those these files are
just pieces of one single configuration.

Examples of software following that notion includes apache, yum,
freetype, rsyslog, sysctl, xinetd etc. The only exception I know
is SysV init which uses /etc/rc.d and /etc/init.d directories, as
well as /etc/rcN.d, and the files in there can be used individually
by the software (i.e. init).

Taking all the above into account, it's better to have /etc/mosaic/
rather than /etc/mosaic.d/, to avoid a user from falsely thinking
that these mosaic files are all parts of the single configuration.

Signed-off-by: Kir Kolyshkin kir@openvz.org
